### PR TITLE
25 ctrl c を実装する

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/va-h/devcontainers-features/uv:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install libreadline-dev -y && uv sync"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ SRCS	= \
 	srcs/get_env_pwd.c\
 	srcs/create_cmd_path.c\
 	srcs/utils/free_string_array.c\
-	srcs/utils/add_slash.c
+	srcs/utils/add_slash.c\
+	srcs/signal_handler.c
+HEADERS	= \
+	includes/minishell.h\
+	includes/core_feature.h\
+	includes/signal_handlings.h\
+	includes/utils.h
 MAIN_OBJ = $(MAIN:.c=.o)
 OBJS	= $(SRCS:.c=.o)
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,12 @@
    ```
 
 ## 自分のPCでのセットアップ
-1. uv のインストール
-
-   ```
-   $ pip install uv
-   ```
+1. Dev Containerの立ち上げ
+VSCodeを起動したら、右下に Rebuild and Reopen in Container みたいなのが出てくるので、それをクリック
 
 2. python の仮想環境構築
 
    ```
-   $ uv sync
    $ source .venv/bin/activate
    ```
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -16,6 +16,7 @@
 # include "../libft/libft.h"
 # include "core_features.h"
 # include "utils.h"
+# include "signal_handlings.h"
 
 # include <stdio.h>
 # include <readline/readline.h>
@@ -28,5 +29,7 @@
 # include <assert.h>
 # include <string.h>
 # include <fcntl.h>
+
+extern volatile sig_atomic_t	sig_flag;
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+        */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/16 22:27:24 by takitaga          #+#    #+#             */
-/*   Updated: 2025/03/08 14:01:08 by yohatana         ###   ########.fr       */
+/*   Updated: 2025/03/15 13:25:06 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,6 @@
 # include <string.h>
 # include <fcntl.h>
 
-extern volatile sig_atomic_t	sig_flag;
+extern volatile sig_atomic_t	g_sig_flag;
 
 #endif

--- a/includes/signal_handlings.h
+++ b/includes/signal_handlings.h
@@ -6,10 +6,9 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/15 21:12:27 by takitaga          #+#    #+#             */
-/*   Updated: 2025/03/15 21:19:09 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/03/15 13:24:58 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
-
 
 #ifndef SIGNAL_HANDLINGS_H
 # define SIGNAL_HANDLINGS_H

--- a/includes/signal_handlings.h
+++ b/includes/signal_handlings.h
@@ -1,0 +1,21 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal_handlings.h                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/15 21:12:27 by takitaga          #+#    #+#             */
+/*   Updated: 2025/03/15 21:19:09 by takitaga         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+
+#ifndef SIGNAL_HANDLINGS_H
+# define SIGNAL_HANDLINGS_H
+
+# include <signal.h>
+
+void	handle_sigint(int sig);
+
+#endif

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 19:16:44 by yohatana          #+#    #+#             */
-/*   Updated: 2025/03/15 13:52:06 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/03/15 14:03:07 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,32 +14,42 @@
 
 volatile sig_atomic_t	g_sig_flag;
 
+static void minishell(char **envp);
 static char	*get_input_line(void);
 
-int	main(int argc, char **argv, char **envp)
+int	main(int argc, char **envp)
+{
+	g_sig_flag = 0;
+	if (argc != 1)
+		return (0);
+	minishell(envp);
+	return (0);
+}
+
+static void	minishell(char **envp)
 {
 	char	*line;
 
-	(void)argv;
-	g_sig_flag = 0;
 	if (signal(SIGINT, handle_sigint) == SIG_ERR)
 	{
-		perror("signal");
-		return (1);
+		perror(NULL);
+		exit(EXIT_FAILURE);
 	}
-	if (argc != 1)
-		return (0);
 	while (1)
 	{
 		line = get_input_line();
+		if (!line)
+		{
+			write(STDOUT_FILENO, "exit\n", 5);
+			exit(EXIT_SUCCESS);
+		}
 		if (ft_strlen(line) != 0)
 		{
 			add_history(line);
 			exec_cmd(envp, line);
+			free(line);
 		}
-		free(line);
 	}
-	return (0);
 }
 
 static char	*get_input_line(void)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,13 +6,13 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 19:16:44 by yohatana          #+#    #+#             */
-/*   Updated: 2025/03/15 13:19:51 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/03/15 13:25:31 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
-volatile sig_atomic_t	sig_flag;
+volatile sig_atomic_t	g_sig_flag;
 
 static char	*get_input_line(char *line);
 
@@ -21,7 +21,7 @@ int	main(int argc, char **argv, char **envp)
 	char	*line;
 
 	(void)argv;
-	sig_flag = 0;
+	g_sig_flag = 0;
 	if (signal(SIGINT, handle_sigint) == SIG_ERR)
 	{
 		perror("signal");

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 19:16:44 by yohatana          #+#    #+#             */
-/*   Updated: 2025/03/15 13:25:31 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/03/15 13:52:06 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 volatile sig_atomic_t	g_sig_flag;
 
-static char	*get_input_line(char *line);
+static char	*get_input_line(void);
 
 int	main(int argc, char **argv, char **envp)
 {
@@ -29,10 +29,9 @@ int	main(int argc, char **argv, char **envp)
 	}
 	if (argc != 1)
 		return (0);
-	line = NULL;
 	while (1)
 	{
-		line = get_input_line(line);
+		line = get_input_line();
 		if (ft_strlen(line) != 0)
 		{
 			add_history(line);
@@ -43,10 +42,11 @@ int	main(int argc, char **argv, char **envp)
 	return (0);
 }
 
-static char	*get_input_line(char *line)
+static char	*get_input_line(void)
 {
 	int	stdout_copy;
 	int	dev_null;
+	char	*line;
 
 	if (isatty(STDIN_FILENO))
 		line = readline("minishell> ");

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 19:16:44 by yohatana          #+#    #+#             */
-/*   Updated: 2025/03/15 14:03:07 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/03/15 14:04:09 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 volatile sig_atomic_t	g_sig_flag;
 
-static void minishell(char **envp);
+static void	minishell(char **envp);
 static char	*get_input_line(void);
 
 int	main(int argc, char **envp)
@@ -54,8 +54,8 @@ static void	minishell(char **envp)
 
 static char	*get_input_line(void)
 {
-	int	stdout_copy;
-	int	dev_null;
+	int		stdout_copy;
+	int		dev_null;
 	char	*line;
 
 	if (isatty(STDIN_FILENO))

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,14 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+        */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 19:16:44 by yohatana          #+#    #+#             */
-/*   Updated: 2025/03/06 22:10:49 by yohatana         ###   ########.fr       */
+/*   Updated: 2025/03/15 13:19:51 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
+
+volatile sig_atomic_t	sig_flag;
 
 static char	*get_input_line(char *line);
 
@@ -19,6 +21,12 @@ int	main(int argc, char **argv, char **envp)
 	char	*line;
 
 	(void)argv;
+	sig_flag = 0;
+	if (signal(SIGINT, handle_sigint) == SIG_ERR)
+	{
+		perror("signal");
+		return (1);
+	}
 	if (argc != 1)
 		return (0);
 	line = NULL;
@@ -29,8 +37,8 @@ int	main(int argc, char **argv, char **envp)
 		{
 			add_history(line);
 			exec_cmd(envp, line);
-			free(line);
 		}
+		free(line);
 	}
 	return (0);
 }

--- a/srcs/signal_handler.c
+++ b/srcs/signal_handler.c
@@ -1,0 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signal_handler.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/15 21:12:57 by takitaga          #+#    #+#             */
+/*   Updated: 2025/03/15 13:20:08 by takitaga         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/minishell.h"
+
+void	handle_sigint(int sig)
+{
+	(void)sig;
+	rl_on_new_line();
+	write(STDOUT_FILENO, "\n", 1);
+	rl_replace_line("", 0);
+	rl_redisplay();
+}


### PR DESCRIPTION
# Pull Request

## 概要
readline待機中にctrl+cでsigintが送られてきた場合の処理を実装
readline待機中にctrl+dでEOFが送られてきた場合の処理を実装

## 変更内容
commit見て

## 動作確認項目
```
make
./minishell
```
で、interactiveなshellに入る。ctrl+cを押すと入力内容がクリアされて、改行される

## 補足情報
- 子プロセス実行中のsignal handlingは別タスクで実施。
- devcontainerの設定を追加してる。自分のmacだと校舎PCと環境が合わず、色々と困ったので作ってます。僕が使うので、特に気にしなくてOK
- なんとctrl+dはsignalじゃなくてEOFが送られてきているだけ！
- テスト書くのは、むずすぎてやってない