### PR TITLE
feat: signal handling when excecuting child processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SRCS	= \
 	srcs/get_input_line.c\
 	srcs/create_minishell_struct.c\
 	srcs/pipe/pipe.c\
+	srcs/pipe/pipe_utils.c\
 	srcs/pipe/pipe_process_handlers.c\
 	srcs/pipe/change_fds.c\
 	srcs/exec_builtin_cmd.c\

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/16 22:27:24 by takitaga          #+#    #+#             */
-/*   Updated: 2025/04/19 05:04:27 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/04/22 12:10:40 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,8 @@ typedef struct s_minishell
 	t_env	*env;
 	t_proc	*proc;
 	int		proc_count;
+	pid_t	*child_pids;
+	int		created_child_proc_count;
 }	t_minishell;
 
 t_minishell	*create_minishell_struct(t_env *env);

--- a/includes/pipes.h
+++ b/includes/pipes.h
@@ -6,7 +6,7 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 12:23:12 by yohatana          #+#    #+#             */
-/*   Updated: 2025/04/19 04:40:47 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/04/22 12:31:32 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,5 +24,6 @@ bool	minishell_pipe(t_minishell *minishell);
 void	change_fds(t_minishell *m_shell, int proc_index, int pipe_fd[2][2]);
 void	parent_process(int pipe_fd[2][2], t_proc *proc, int proc_count);
 void	child_process(t_minishell *m_shell, t_proc *proc, int pipe_fd[2][2]);
+void	close_pipe_fd(int pipe_fd[2]);
 
 #endif

--- a/srcs/create_minishell_struct.c
+++ b/srcs/create_minishell_struct.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   create_minishell_struct.c                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+        */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 14:28:21 by yohatana          #+#    #+#             */
-/*   Updated: 2025/04/15 14:42:58 by yohatana         ###   ########.fr       */
+/*   Updated: 2025/04/22 11:58:13 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ t_minishell	*create_minishell_struct(t_env *env)
 	m_shell->env = env;
 	m_shell->prev_status = 0;
 	m_shell->proc_count = 0;
+	m_shell->created_child_proc_count = 0;
 	return (m_shell);
 }
 

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,16 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+        */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 19:16:44 by yohatana          #+#    #+#             */
-/*   Updated: 2025/04/20 19:10:57 by yohatana         ###   ########.fr       */
+/*   Updated: 2025/04/22 12:41:04 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
-
-volatile sig_atomic_t	g_sig_flag;
 
 static void			minishell(t_env *env);
 static void			minishell_loop(t_minishell *m_shell);
@@ -39,13 +37,7 @@ static void	minishell(t_env *env)
 {
 	t_minishell	*m_shell;
 
-	if (signal(SIGINT, handle_sigint) == SIG_ERR)
-	{
-		perror(NULL);
-		free_all_env(env);
-		rl_clear_history();
-		exit(EXIT_FAILURE);
-	}
+	set_handle_sigint(env);
 	m_shell = create_minishell_struct(env);
 	if (!m_shell)
 		return ;

--- a/srcs/pipe/pipe_process_handlers.c
+++ b/srcs/pipe/pipe_process_handlers.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipe_process_handlers.c                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+        */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 04:57:30 by takitaga          #+#    #+#             */
-/*   Updated: 2025/04/20 17:57:24 by yohatana         ###   ########.fr       */
+/*   Updated: 2025/04/22 12:32:09 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,10 +17,7 @@ void	parent_process(int pipe_fd[2][2], t_proc *proc, int proc_count)
 	if (proc_count == 1)
 		return ;
 	if (proc->index != 0)
-	{
-		close(pipe_fd[PREV][READ]);
-		close(pipe_fd[PREV][WRITE]);
-	}
+		close_pipe_fd(pipe_fd[PREV]);
 	if (proc->next)
 	{
 		pipe_fd[PREV][READ] = pipe_fd[CURR][READ];

--- a/srcs/pipe/pipe_utils.c
+++ b/srcs/pipe/pipe_utils.c
@@ -1,23 +1,19 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   signal_handlings.h                                 :+:      :+:    :+:   */
+/*   pipe_utils.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/03/15 21:12:27 by takitaga          #+#    #+#             */
-/*   Updated: 2025/04/22 12:20:06 by takitaga         ###   ########.fr       */
+/*   Created: 2025/04/22 12:29:50 by takitaga          #+#    #+#             */
+/*   Updated: 2025/04/22 12:32:47 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef SIGNAL_HANDLINGS_H
-# define SIGNAL_HANDLINGS_H
+#include "../../includes/minishell.h"
 
-# include <signal.h>
-
-void	handle_sigint(int sig);
-void	handle_sigint_pipe(int sig);
-void	set_handle_sigint(t_env *env);
-bool	set_handle_sigint_pipe(t_minishell *m_shell);
-
-#endif
+void	close_pipe_fd(int pipe_fd[2])
+{
+	close(pipe_fd[READ]);
+	close(pipe_fd[WRITE]);
+}

--- a/srcs/signal_handler.c
+++ b/srcs/signal_handler.c
@@ -6,11 +6,13 @@
 /*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/15 21:12:57 by takitaga          #+#    #+#             */
-/*   Updated: 2025/03/27 14:31:48 by takitaga         ###   ########.fr       */
+/*   Updated: 2025/04/22 12:41:10 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
+
+volatile sig_atomic_t	g_sig_flag;
 
 void	handle_sigint(int sig)
 {
@@ -19,4 +21,34 @@ void	handle_sigint(int sig)
 	ft_putendl_fd("", STDOUT_FILENO);
 	rl_replace_line("", 0);
 	rl_redisplay();
+}
+
+void	handle_sigint_pipe(int sig)
+{
+	(void)sig;
+	g_sig_flag = 1;
+	ft_putendl_fd("", STDOUT_FILENO);
+}
+
+void	set_handle_sigint(t_env *env)
+{
+	if (signal(SIGINT, handle_sigint) == SIG_ERR)
+	{
+		perror(NULL);
+		free_all_env(env);
+		rl_clear_history();
+		exit(EXIT_FAILURE);
+	}
+}
+
+bool	set_handle_sigint_pipe(t_minishell *m_shell)
+{
+	if (signal(SIGINT, handle_sigint_pipe) == SIG_ERR)
+	{
+		perror("signal failed");
+		free(m_shell->child_pids);
+		m_shell->child_pids = NULL;
+		return (true);
+	}
+	return (false);
 }

--- a/tests/unit/create_cmd_path.test.c
+++ b/tests/unit/create_cmd_path.test.c
@@ -3,6 +3,7 @@
 // TODO :serch_exec_cmd_path()
 // 	when 'return cmd_only',
 // 	error message shoud be "command not found"
+
 int	main(int argc, char **argv, char **envp)
 {
 	char	*path;


### PR DESCRIPTION
# Pull Request

## 概要

子プロセス実行中のシグナルハンドリング(CTRL+C)を実装！
exit statusも設定したよ。

## 動作確認項目

手元で動作確認した。
```
(minishell) vscode ➜ /workspaces/minishell (66-ctrl-c-を実装する-子プロセス実行中) $ ./minishell 
minishell> ls | sleep 1 | sleep 1
minishell> echo -n $?
0minishell> ls | sleep 1 | sleep 1
^C
minishell> echo -n $?
130minishell> ls | sleep 1 | sleep 1
^C
minishell> echo -n $?
130minishell> 
exit
```

## 補足情報

まあいい感じだと思う。動いてるし。
