### PR TITLE
fix: alloced memories for value string in search_env_value

### DIFF
--- a/srcs/parser/expand_dollar.c
+++ b/srcs/parser/expand_dollar.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand_dollar.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+        */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 20:33:45 by yohatana          #+#    #+#             */
-/*   Updated: 2025/04/25 16:19:36 by yohatana         ###   ########.fr       */
+/*   Updated: 2025/04/26 14:29:59 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,7 +100,7 @@ static bool	replace_env_word(t_token *curr, int *index, t_minishell *m_shell)
 		*index = *index + 1;
 		return (false);
 	}
-	replace.value = ft_strdup(search_env_value(replace.key, m_shell));
+	replace.value = search_env_value(replace.key, m_shell);
 	if (replace_word(curr, index, replace))
 	{
 		free(replace.key);

--- a/srcs/parser/expand_dollar_util.c
+++ b/srcs/parser/expand_dollar_util.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   expand_dollar_util.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yohatana <yohatana@student.42.fr>          +#+  +:+       +#+        */
+/*   By: takitaga <takitaga@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/30 13:18:13 by yohatana          #+#    #+#             */
-/*   Updated: 2025/04/25 16:30:44 by yohatana         ###   ########.fr       */
+/*   Updated: 2025/04/26 14:33:40 by takitaga         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,15 +49,17 @@ static char	*split_after_word(t_token *curr, int *index, t_env replace)
 char	*search_env_value(char *key, t_minishell *m_shell)
 {
 	t_env	*find;
-	char	*status;
+	char	*value_str;
 
 	if (ft_strcmp(key, "$?") == 0)
 	{
-		status = ft_itoa(m_shell->prev_status);
-		return (status);
+		value_str = ft_itoa(m_shell->prev_status);
+		return (value_str);
 	}
 	find = search_env(key, m_shell->env);
 	if (find == NULL)
-		return ("");
-	return (find->value);
+		value_str = ft_strdup("");
+	else
+		value_str = ft_strdup(find->value);
+	return (value_str);
 }


### PR DESCRIPTION
# Pull Request

## 概要

search_env_value関数の中で、
文字列リテラルが返される部分とitoaでメモリ確保されて返される部分を、メモリ確保で統一。

## 動作確認項目

```
> make valgrind
minishell > echo $?
```

でリークなし。
一応他のenvでも試してリークなし。
```
> make valgrind
minishell > echo $USER
```
```
> make valgrind
minishell > echo $NON_EXISTS
```
